### PR TITLE
chore: upgrade flutter 2.0.2

### DIFF
--- a/lib/backend/app_state_store.dart
+++ b/lib/backend/app_state_store.dart
@@ -39,7 +39,7 @@ class AppStateStore {
   bool get isNotEmpty => !isEmpty;
 
   void clear() {
-    selectedCalendar.value = null;
+    selectedCalendar.add(null);
     _data.clear();
   }
 }

--- a/lib/backend/repositories/calendar_repository.dart
+++ b/lib/backend/repositories/calendar_repository.dart
@@ -217,7 +217,7 @@ class CalendarRepository extends Repository {
       return;
     }
 
-    _appState.selectedCalendar.value = calendar;
+    _appState.selectedCalendar.add(calendar);
     _resetEventCheckTimer();
   }
 

--- a/lib/backend/services/face_detection_service.dart
+++ b/lib/backend/services/face_detection_service.dart
@@ -42,7 +42,7 @@ class FaceDetectionService extends Service {
   void _setFacesDetected(bool detected) {
     if (_facesDetected.value != detected) {
       _log.function('_setFacesDetected', 'Setting _facesDetected to $detected');
-      _facesDetected.value = detected;
+      _facesDetected.add(detected);
     }
   }
 

--- a/lib/ux/main_container.dart
+++ b/lib/ux/main_container.dart
@@ -18,14 +18,16 @@ class MainContainer extends StatelessWidget {
       type: MaterialType.transparency,
       child: Stack(
         children: <Widget>[
-          Scaffold(
-            backgroundColor: AppTheme.colorBackgroundDark,
-            key: _scaffoldKey,
-            drawer: CalendarSelectDrawer(),
-            endDrawer: DebugDrawer(),
-            body: const Padding(
-              padding: EdgeInsets.all(8.0),
-              child: EventScreen(),
+          ScaffoldMessenger(
+            child: Scaffold(
+              backgroundColor: AppTheme.colorBackgroundDark,
+              key: _scaffoldKey,
+              drawer: CalendarSelectDrawer(),
+              endDrawer: DebugDrawer(),
+              body: const Padding(
+                padding: EdgeInsets.all(8.0),
+                child: EventScreen(),
+              ),
             ),
           ),
           Align(

--- a/lib/ux/main_container/screens/event_screen/animation_section.dart
+++ b/lib/ux/main_container/screens/event_screen/animation_section.dart
@@ -26,7 +26,7 @@ class _AnimationSectionState extends State<AnimationSection> {
     super.initState();
     final stateStream = backend.animationService.state;
 
-    _controller.play('${stateStream.value}');
+    _controller.play('${stateStream.valueWrapper.value}');
 
     _subscription = stateStream.listen((state) {
       _controller.play('$state');

--- a/lib/ux/widgets/ml_vision_camera.dart
+++ b/lib/ux/widgets/ml_vision_camera.dart
@@ -9,7 +9,6 @@ import 'package:flutter/services.dart';
 
 import 'package:camera/camera.dart';
 import 'package:firebase_ml_vision/firebase_ml_vision.dart';
-import 'package:path_provider/path_provider.dart';
 
 import 'package:socialbuddybot/utils/utils.dart';
 

--- a/lib/ux/widgets/widget_utils.dart
+++ b/lib/ux/widgets/widget_utils.dart
@@ -96,7 +96,7 @@ void _showSnackBar({
   @required String message,
   Duration duration,
 }) {
-  final state = Scaffold.of(context);
+  final state = ScaffoldMessenger.of(context);
 
   state
     ..removeCurrentSnackBar(reason: SnackBarClosedReason.dismiss)

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -7,14 +7,14 @@ packages:
       name: _fe_analyzer_shared
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.3"
+    version: "14.0.0"
   analyzer:
     dependency: transitive
     description:
       name: analyzer
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.39.4"
+    version: "0.41.2"
   archive:
     dependency: transitive
     description:
@@ -29,34 +29,27 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.6.0"
-  asn1lib:
-    dependency: transitive
-    description:
-      name: asn1lib
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "0.6.5"
   async:
     dependency: transitive
     description:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.4.0"
+    version: "2.5.0"
   basic_utils:
     dependency: transitive
     description:
       name: basic_utils
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.6.0"
+    version: "2.7.0-rc.4"
   build:
     dependency: transitive
     description:
       name: build
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.2"
+    version: "1.5.2"
   build_config:
     dependency: transitive
     description:
@@ -70,63 +63,63 @@ packages:
       name: build_daemon
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.3"
+    version: "2.1.10"
   build_resolvers:
     dependency: transitive
     description:
       name: build_resolvers
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.3"
+    version: "1.4.4"
   build_runner:
     dependency: "direct dev"
     description:
       name: build_runner
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.1"
+    version: "1.11.1"
   build_runner_core:
     dependency: transitive
     description:
       name: build_runner_core
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "5.0.0"
+    version: "6.0.3"
   built_collection:
     dependency: transitive
     description:
       name: built_collection
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.3.2"
+    version: "5.0.0"
   built_value:
     dependency: transitive
     description:
       name: built_value
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "7.0.9"
+    version: "8.0.3"
   camera:
     dependency: "direct main"
     description:
       name: camera
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.7.0+2"
+    version: "0.8.0"
   camera_platform_interface:
     dependency: transitive
     description:
       name: camera_platform_interface
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.5.0"
+    version: "2.0.1"
   characters:
     dependency: transitive
     description:
       name: characters
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0-nullsafety.3"
+    version: "1.1.0"
   charcode:
     dependency: transitive
     description:
@@ -141,20 +134,27 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.0.2"
+  cli_util:
+    dependency: transitive
+    description:
+      name: cli_util
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.3.0"
   code_builder:
     dependency: transitive
     description:
       name: code_builder
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.2.1"
+    version: "3.7.0"
   collection:
     dependency: "direct main"
     description:
       name: collection
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.15.0-nullsafety.3"
+    version: "1.15.0"
   colorize:
     dependency: transitive
     description:
@@ -175,28 +175,21 @@ packages:
       name: cross_file
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.0"
+    version: "0.3.1+1"
   crypto:
     dependency: transitive
     description:
       name: crypto
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.3"
-  csslib:
-    dependency: transitive
-    description:
-      name: csslib
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "0.16.1"
+    version: "2.1.5"
   dart_style:
     dependency: transitive
     description:
       name: dart_style
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.3"
+    version: "1.3.10"
   device_calendar:
     dependency: "direct main"
     description:
@@ -204,20 +197,34 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "3.1.0"
+  ffi:
+    dependency: transitive
+    description:
+      name: ffi
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.0.0"
+  file:
+    dependency: transitive
+    description:
+      name: file
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "6.1.0"
   firebase_ml_vision:
     dependency: "direct main"
     description:
       name: firebase_ml_vision
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.10.0"
+    version: "0.11.0"
   fixnum:
     dependency: transitive
     description:
       name: fixnum
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.10.11"
+    version: "1.0.0"
   flare_dart:
     dependency: transitive
     description:
@@ -250,7 +257,7 @@ packages:
       name: flutter_svg
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.18.1"
+    version: "0.19.3"
   flutter_tts_improved:
     dependency: "direct main"
     description:
@@ -264,14 +271,14 @@ packages:
       name: font_awesome_flutter
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "8.11.0"
+    version: "8.12.0"
   get_it:
     dependency: "direct main"
     description:
       name: get_it
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "5.0.6"
+    version: "6.0.0"
   glob:
     dependency: transitive
     description:
@@ -286,13 +293,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.2.0"
-  html:
-    dependency: transitive
-    description:
-      name: html
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "0.14.0+3"
   http:
     dependency: transitive
     description:
@@ -328,13 +328,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "4.2.1"
-  intl:
-    dependency: transitive
-    description:
-      name: intl
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "0.16.1"
   io:
     dependency: transitive
     description:
@@ -355,14 +348,14 @@ packages:
       name: json_annotation
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.0.1"
+    version: "3.1.1"
   json_serializable:
     dependency: "direct dev"
     description:
       name: json_serializable
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.3.0"
+    version: "3.5.1"
   logging:
     dependency: transitive
     description:
@@ -376,14 +369,14 @@ packages:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.6"
+    version: "0.12.10"
   meta:
     dependency: transitive
     description:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0-nullsafety.3"
+    version: "1.3.0"
   mime:
     dependency: transitive
     description:
@@ -418,21 +411,14 @@ packages:
       name: package_info
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.3+4"
-  package_resolver:
-    dependency: transitive
-    description:
-      name: package_resolver
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.0.10"
+    version: "2.0.0"
   path:
     dependency: transitive
     description:
       name: path
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.6.4"
+    version: "1.8.0"
   path_drawing:
     dependency: transitive
     description:
@@ -453,14 +439,42 @@ packages:
       name: path_provider
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.5.1"
+    version: "2.0.1"
+  path_provider_linux:
+    dependency: transitive
+    description:
+      name: path_provider_linux
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.0"
+  path_provider_macos:
+    dependency: transitive
+    description:
+      name: path_provider_macos
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.0"
+  path_provider_platform_interface:
+    dependency: transitive
+    description:
+      name: path_provider_platform_interface
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.1"
+  path_provider_windows:
+    dependency: transitive
+    description:
+      name: path_provider_windows
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.0"
   pedantic:
     dependency: "direct dev"
     description:
       name: pedantic
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0+1"
+    version: "1.11.0"
   petitparser:
     dependency: transitive
     description:
@@ -474,21 +488,21 @@ packages:
       name: platform
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.2.1"
+    version: "3.0.0"
   plugin_platform_interface:
     dependency: transitive
     description:
       name: plugin_platform_interface
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.3"
+    version: "2.0.0"
   pointycastle:
     dependency: transitive
     description:
       name: pointycastle
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.2"
+    version: "2.0.1"
   pool:
     dependency: transitive
     description:
@@ -496,6 +510,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.4.0"
+  process:
+    dependency: transitive
+    description:
+      name: process
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "4.1.0"
   pub_semver:
     dependency: transitive
     description:
@@ -516,7 +537,7 @@ packages:
       name: quiver
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.5"
+    version: "3.0.0"
   random_string:
     dependency: transitive
     description:
@@ -530,7 +551,7 @@ packages:
       name: rxdart
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.25.0"
+    version: "0.26.0"
   shelf:
     dependency: transitive
     description:
@@ -556,7 +577,7 @@ packages:
       name: source_gen
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.9.4+7"
+    version: "0.9.10+3"
   source_span:
     dependency: transitive
     description:
@@ -570,14 +591,14 @@ packages:
       name: stack_trace
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.9.3"
+    version: "1.10.0"
   state_persistence:
     dependency: "direct main"
     description:
       name: state_persistence
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.0.7"
+    version: "0.1.0"
   stream_channel:
     dependency: transitive
     description:
@@ -591,7 +612,7 @@ packages:
       name: stream_transform
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "2.0.0"
   string_scanner:
     dependency: transitive
     description:
@@ -612,7 +633,7 @@ packages:
       name: time
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.4.0"
+    version: "2.0.0"
   timing:
     dependency: transitive
     description:
@@ -626,7 +647,7 @@ packages:
       name: typed_data
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0-nullsafety.3"
+    version: "1.3.0"
   validators:
     dependency: "direct main"
     description:
@@ -640,7 +661,7 @@ packages:
       name: vector_math
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0-nullsafety.3"
+    version: "2.1.0"
   vin_decoder:
     dependency: transitive
     description:
@@ -662,6 +683,20 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.1.0"
+  win32:
+    dependency: transitive
+    description:
+      name: win32
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.4"
+  xdg_directories:
+    dependency: transitive
+    description:
+      name: xdg_directories
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.2.0"
   xml:
     dependency: transitive
     description:
@@ -677,5 +712,5 @@ packages:
     source: hosted
     version: "2.2.0"
 sdks:
-  dart: ">=2.10.0-110 <2.11.0"
-  flutter: ">=1.22.6 <2.0.0"
+  dart: ">=2.12.0 <3.0.0"
+  flutter: ">=2.0.2"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,24 +4,24 @@ version: 2.0.2
 
 environment:
   sdk: ">=2.7.0 <3.0.0"
-  flutter: ^1.22.6
+  flutter: 2.0.2
 
 dependencies:
   flutter:
     sdk: flutter
-  camera: ^0.7.0+2
-  collection: ^1.14.12
+  camera: ^0.8.0
+  collection: ^1.15.0
   device_calendar: ^3.1.0
-  firebase_ml_vision: ^0.10.0
+  firebase_ml_vision: ^0.11.0
   flare_flutter: ^2.0.6
-  flutter_svg: ^0.18.0
+  flutter_svg: ^0.19.3
   flutter_tts_improved: ^1.0.3
-  font_awesome_flutter: ^8.11.0
-  get_it: ^5.0.6
-  package_info: ^0.4.3+4
-  rxdart: ^0.25.0
-  state_persistence: ^0.0.7
-  time: ^1.4.0
+  font_awesome_flutter: ^8.12.0
+  get_it: ^6.0.0
+  package_info: ^2.0.0
+  rxdart: ^0.26.0
+  state_persistence: ^0.1.0
+  time: ^2.0.0
   validators: ^2.0.1
 
 dev_dependencies:
@@ -29,7 +29,7 @@ dev_dependencies:
   flutter_launcher_icons: ^0.7.4
   import_sorter: ^4.2.1
   json_serializable: ^3.3.0
-  pedantic: 1.8.0+1
+  pedantic:
 
 flutter:
   uses-material-design: true


### PR DESCRIPTION
This PR upgrades Flutter to 2.0.2 and all its dependencies to the latest version.

These changes have not yet been tested on a real device.